### PR TITLE
Add key prop and useMemo hook to CartItems loop

### DIFF
--- a/src/Pages/cart.jsx
+++ b/src/Pages/cart.jsx
@@ -1,10 +1,12 @@
-import React, { useState } from 'react'
+import React, { useMemo } from 'react'
 import Header from '../Components/Header'
 import { CartItems, CartProperties } from './Data/cart-data'
 import './styles/cart.css'
 
 const Cart = () => {
-    let subtotal = 0;
+    const subtotal = useMemo(() => {
+    return CartItems.reduce((acc, item) => acc + item.price * item.quantity, 0);
+  }, []);
 
     return (
         <div className='cart-master'>
@@ -12,10 +14,8 @@ const Cart = () => {
 
                 <h1 className='cart-heading'>My Cart</h1>
 
-                <div className='cart-product-list-sec'>
-                    {CartItems.map((item, index) => {
-                        subtotal = subtotal + item.price;
-                        return (
+                <section className='cart-product-list-sec'>
+                {CartItems.map((item) => (
                             <div>
                                 <img src={item.img} alt={item.product_name} />
                                 <h3 className='cart-items-title'>{item.product_name}</h3>
@@ -26,9 +26,8 @@ const Cart = () => {
                                 <label className='cart-subtotal-label'>Subtotal</label>
                                 <span className='cart-subtotal'>{item.price * item.quantity}</span>
                             </div>
-                        )
-                    })}
-                </div>
+                ))}
+                </section>
 
                 <div className='cart-summary-sec'>
                     <h2 className='cart-summary-heading' >Order Summary</h2>


### PR DESCRIPTION
The old code renders the CartItems array's list of items without a `key prop`, which might cause unexpected behavior and performance problems when new or deleted items are inserted.

Assuming that each displayed item has a distinct identification, I added a `key prop` to each item using the `item.id` property in the revised code. This allows React to effectively refresh the list of items whenever a change is made without having to render the full list again.